### PR TITLE
streamlit-feedback 0.1.3 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "streamlit-feedback" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 90f198a4e116e901aaf08058261d444f0abcd3a365bac8c5d6fc08a3c05e02a2
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  # s390x is missing streamlit
+  skip: true  # [py<37 or s390x]
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+    - streamlit >=0.63
+  run:
+    - python
+    - streamlit >=0.63
+
+test:
+  imports:
+    - streamlit_feedback
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/trubrics/streamlit-feedback
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Streamlit component that allows you to collect user feedback in your apps
+  description: |
+    A Streamlit component to add user feedback to your apps.
+  doc_url: https://github.com/trubrics/streamlit-feedback/blob/main/README.md
+  dev_url: https://github.com/trubrics/streamlit-feedback
+
+extra:
+  recipe-maintainers:
+    - psteyer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - python
     - setuptools
     - wheel
-    - streamlit >=0.63
   run:
     - python
     - streamlit >=0.63


### PR DESCRIPTION
streamlit-feedback 0.1.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4476](https://anaconda.atlassian.net/browse/PKG-4476) 
- [Upstream repository](https://github.com/trubrics/streamlit-feedback/tree/main)

### Explanation of changes:

- initial package creation using `conda-skeleton`
- added `skip` for `s390x`

[PKG-4476]: https://anaconda.atlassian.net/browse/PKG-4476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ